### PR TITLE
Fix scan timestamps

### DIFF
--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -177,6 +177,7 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
         !(iter_z != iter_z.end()))
       {
         RCLCPP_INFO_THROTTLE(get_logger(), steady_clock, .3, "x, y, z and index fields are required, skipping scan");
+        return false;
       }
 
     for (;


### PR DESCRIPTION
Un pequeño arreglo, originalmente aplicado sobre la rama `ros2` en [upstream](https://github.com/ros-perception/laser_filters/tree/ros2). Quizas convenga traer la rama completa a este repo @lucianoperetti.